### PR TITLE
init new pairs with prices at last jump date or at bot start date when live adding coin

### DIFF
--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -2,12 +2,23 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/erwanlbp/trading-bot/pkg/config"
+	"github.com/erwanlbp/trading-bot/pkg/util"
 )
 
 func main() {
 	conf := config.Init(context.Background())
 
-	conf.ProcessCleaner.CleanPairHistory()
+	util.DebugPrintJson(conf.BinanceClient.GetSymbolInfos(context.Background(), "DOGEUSDT"))
+
+	date := time.Date(2024, 03, 30, 9, 58, 0, 0, time.UTC)
+
+	for {
+		date = date.Add(12 * time.Hour)
+		fmt.Println(date)
+		util.DebugPrintJson(conf.BinanceClient.GetSymbolPriceAtTime(context.TODO(), "DOGE", "USDT", date))
+	}
 }

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -2,12 +2,22 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/erwanlbp/trading-bot/pkg/config"
+	"github.com/erwanlbp/trading-bot/pkg/util"
+	"go.uber.org/zap"
 )
 
 func main() {
 	conf := config.Init(context.Background())
 
-	conf.ProcessCleaner.CleanCoinPrice()
+	if err := conf.DB.MigrateSchema(); err != nil {
+		conf.Logger.Fatal("failed to migrate DB schema", zap.Error(err))
+	}
+
+	date := time.Date(2024, 3, 30, 12, 2, 12, 0, time.Local)
+	conf.Logger.Debug(fmt.Sprintf("fetching price at time %s", date))
+	util.DebugPrintJson(conf.BinanceClient.GetSymbolPriceAtTime(context.Background(), "DOGE", "USDT", date))
 }

--- a/pkg/binance/coin.go
+++ b/pkg/binance/coin.go
@@ -85,7 +85,7 @@ func (c *Client) GetSymbolPriceAtTime(ctx context.Context, coin, altCoin string,
 	}
 
 	if len(prices) == 0 {
-		return CoinPrice{}, errors.New("No price found, if the coin didn't exist, maybe don't put it in your list !")
+		return CoinPrice{}, ErrNoPriceFoundAtTime
 	}
 	kline := prices[0]
 

--- a/pkg/binance/coin.go
+++ b/pkg/binance/coin.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/adshao/go-binance/v2"
@@ -31,10 +30,15 @@ func (c *Client) GetCoinsPrice(ctx context.Context, coins, altCoins []string) (m
 	symbols := getSymbols(coins, altCoins, c.SymbolBlackList)
 
 	if len(symbols) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("no symbols found")
 	}
 
-	prices, err := getPrices(ctx, symbols, c)
+	prices, err := c.client.NewListPricesService().Symbols(symbols).Do(ctx)
+	if err != nil {
+		if ErrorIs(err, BinanceErrorInvalidSymbol) {
+			prices, err = c.dichotomicPriceFetching(ctx, symbols)
+		}
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -61,60 +65,59 @@ func (c *Client) GetCoinsPrice(ctx context.Context, coins, altCoins []string) (m
 	return res, nil
 }
 
-// Sorted by price and altcoin name
-func (c *Client) GetCoinsPriceGroupByAltCoins(ctx context.Context, coins, altCoins []string) (map[string]CoinPriceGroupByAlt, error) {
+func (c *Client) GetSymbolPriceAtTime(ctx context.Context, coin, altCoin string, date time.Time) (CoinPrice, error) {
 
-	symbols := getSymbols(coins, altCoins, c.SymbolBlackList)
+	symbols := getSymbols([]string{coin}, []string{altCoin}, c.SymbolBlackList)
 
 	if len(symbols) == 0 {
-		return nil, nil
+		return CoinPrice{}, fmt.Errorf("no symbols found")
 	}
+	symbol := symbols[0]
 
-	prices, err := getPrices(ctx, symbols, c)
+	prices, err := c.client.NewKlinesService().
+		Symbol(symbol).
+		Interval("1m").
+		Limit(1).
+		EndTime(date.UnixMilli()).
+		Do(ctx)
 	if err != nil {
-		return nil, err
-	}
-	now := time.Now().UTC()
-
-	var res = make(map[string]CoinPriceGroupByAlt)
-
-	balanceGroupByCoin := util.GroupByProperty(prices, func(s *binance.SymbolPrice) string {
-		coin, _, _ := util.Unsymbol(s.Symbol, coins, altCoins)
-		return coin
-	})
-
-	for coin, symbolPrices := range balanceGroupByCoin {
-		var resTmp []CoinPrice
-		sort.Slice(symbolPrices, func(i, j int) bool {
-			return symbolPrices[i].Symbol < symbolPrices[j].Symbol
-		})
-
-		for _, price := range symbolPrices {
-			_, altCoin, err := util.Unsymbol(price.Symbol, coins, altCoins)
-			if err != nil {
-				return nil, fmt.Errorf("couldn't unsymbol %s: %w", coin, err)
-			}
-			p, err := decimal.NewFromString(price.Price)
-			if err != nil {
-				return nil, fmt.Errorf("failed parsing price for %s(%s): %w", price.Symbol, price.Price, err)
-			}
-			resTmp = append(resTmp, CoinPrice{
-				Coin:      coin,
-				AltCoin:   altCoin,
-				Price:     p,
-				Timestamp: now,
-			})
-		}
-		res[coin] = CoinPriceGroupByAlt{
-			Coin:   coin,
-			Prices: resTmp,
-		}
+		return CoinPrice{}, err
 	}
 
-	return res, nil
+	if len(prices) == 0 {
+		return CoinPrice{}, errors.New("No price found, if the coin didn't exist, maybe don't put it in your list !")
+	}
+	kline := prices[0]
+
+	// Average the price between the open and close of the candle
+	var pricesToAvg []decimal.Decimal
+	open, err := decimal.NewFromString(kline.Open)
+	if err == nil {
+		pricesToAvg = append(pricesToAvg, open)
+	}
+	close, err := decimal.NewFromString(kline.Close)
+	if err == nil {
+		pricesToAvg = append(pricesToAvg, close)
+	}
+	if len(pricesToAvg) == 0 {
+		return CoinPrice{}, errors.New("couldn't find/parse prices")
+	}
+
+	finalPrice := decimal.Zero
+	for _, price := range pricesToAvg {
+		finalPrice = finalPrice.Add(price)
+	}
+	finalPrice = finalPrice.Div(decimal.NewFromInt(int64(len(pricesToAvg))))
+
+	return CoinPrice{
+		Coin:      coin,
+		AltCoin:   altCoin,
+		Price:     finalPrice,
+		Timestamp: date,
+	}, nil
 }
 
-func getSymbols(coins []string, altCoins []string, blacklist SymbolBlackListGetter) map[string]bool {
+func getSymbols(coins []string, altCoins []string, blacklist SymbolBlackListGetter) []string {
 	var symbols = make(map[string]bool)
 	for _, coin := range coins {
 		for _, altCoin := range altCoins {
@@ -126,18 +129,7 @@ func getSymbols(coins []string, altCoins []string, blacklist SymbolBlackListGett
 			}
 		}
 	}
-	return symbols
-}
-
-func getPrices(ctx context.Context, symbols map[string]bool, c *Client) ([]*binance.SymbolPrice, error) {
-	uniqueSymbols := util.Keys(symbols)
-	prices, err := c.client.NewListPricesService().Symbols(uniqueSymbols).Do(ctx)
-	if err != nil {
-		if ErrorIs(err, BinanceErrorInvalidSymbol) {
-			prices, err = c.dichotomicPriceFetching(ctx, uniqueSymbols)
-		}
-	}
-	return prices, err
+	return util.Keys(symbols)
 }
 
 func (c *Client) GetSymbolPrice(ctx context.Context, symbol string) (decimal.Decimal, error) {

--- a/pkg/binance/error.go
+++ b/pkg/binance/error.go
@@ -1,6 +1,8 @@
 package binance
 
 import (
+	"errors"
+
 	"github.com/adshao/go-binance/v2/common"
 )
 
@@ -8,6 +10,8 @@ const (
 	BinanceErrorInvalidSymbol   int64 = -1121
 	BinanceErrorInvalidQuantity int64 = -1013
 )
+
+var ErrNoPriceFoundAtTime = errors.New("no_price_found_at_time")
 
 func ErrorIs(err error, code int64) bool {
 	if err == nil {

--- a/pkg/model/pair.go
+++ b/pkg/model/pair.go
@@ -16,8 +16,9 @@ type Pair struct {
 	ToCoin   string
 	Exists   bool
 
-	LastJump      time.Time
-	LastJumpRatio decimal.Decimal
+	LastJump             time.Time
+	LastJumpRatio        decimal.Decimal
+	LastJumpRatioBasedOn time.Time
 
 	FromCoinDetail Coin `gorm:"foreignKey:FromCoin"`
 	ToCoinDetail   Coin `gorm:"foreignKey:ToCoin"`

--- a/pkg/process/jump_finder.go
+++ b/pkg/process/jump_finder.go
@@ -402,8 +402,10 @@ func (p *JumpFinder) UpdatePairsToCoinRatios(ctx context.Context, pair model.Pai
 		if pair.FromCoin == pa.FromCoin && pair.ToCoin == pa.ToCoin {
 			pa.LastJump = buy.Time()
 			pa.LastJumpRatio = sell.Price().Div(buy.Price())
+			pa.LastJumpRatioBasedOn = pa.LastJump
 		} else {
 			pa.LastJumpRatio = prices[util.Symbol(pa.FromCoin, p.ConfigFile.Bridge)].Price.Div(buy.Price())
+			pa.LastJumpRatioBasedOn = buy.Time()
 		}
 		pairsToSave = append(pairsToSave, pa)
 	}

--- a/pkg/process/price_getter.go
+++ b/pkg/process/price_getter.go
@@ -57,11 +57,15 @@ func (p *PriceGetter) Start(ctx context.Context) {
 func (p *PriceGetter) FetchCoinsPrices(ctx context.Context) {
 	logger := p.Logger.With(zap.String("process", "fetch_price"))
 
-	// TODO Should we get all coins, not just enabled, so that we could run the algorithm on more than just enabled coins to "propose" some new coins
-	coins, err := p.Repository.GetEnabledCoins()
+	coinModels, err := p.Repository.GetAllCoins()
 	if err != nil {
 		logger.Error("Failed to fetch enabled coins, stopping there", zap.Error(err))
 		return
+	}
+
+	var coins []string
+	for _, coin := range coinModels {
+		coins = append(coins, coin.Coin)
 	}
 
 	prices, err := p.BinanceClient.GetCoinsPrice(ctx, coins, p.AltCoins)

--- a/pkg/repository/coin.go
+++ b/pkg/repository/coin.go
@@ -10,6 +10,10 @@ import (
 	"github.com/erwanlbp/trading-bot/pkg/model"
 )
 
+func (r *Repository) DisableCoin(coin string) error {
+	return r.DB.DB.Table(model.CoinTableName).Where("coin = ?", coin).Update("enabled", 0).Error
+}
+
 func (r *Repository) GetCurrentCoin() (model.CurrentCoin, bool, error) {
 	var res model.CurrentCoin
 	err := r.DB.Order("timestamp desc").Limit(1).Find(&res).Error

--- a/pkg/repository/jump.go
+++ b/pkg/repository/jump.go
@@ -4,9 +4,16 @@ import (
 	"github.com/erwanlbp/trading-bot/pkg/model"
 )
 
-func (r *Repository) GetJumps(number int) ([]model.Jump, error) {
+func (r *Repository) GetJumps(filters ...QueryFilter) ([]model.Jump, error) {
 	var res []model.Jump
-	err := r.DB.Order("timestamp desc").Limit(number).Find(&res).Error
+
+	req := r.DB.DB
+
+	for _, f := range filters {
+		req = f(req)
+	}
+
+	err := req.Find(&res).Error
 	if err != nil {
 		return res, err
 	}

--- a/pkg/repository/misc.go
+++ b/pkg/repository/misc.go
@@ -1,0 +1,36 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/erwanlbp/trading-bot/pkg/model"
+)
+
+func (r *Repository) GetBotFirstLaunch() (time.Time, error) {
+	// We say that the first jump sets the first bot activity
+	{
+		var res model.Jump
+		err := r.DB.DB.Order("timestamp").Limit(1).Find(&res).Error
+		if err != nil {
+			return time.Time{}, err
+		}
+		if !res.Timestamp.IsZero() {
+			return res.Timestamp, err
+		}
+	}
+
+	// If we never jumped, we use the first coin_price we have
+	{
+		var res model.CoinPrice
+		err := r.DB.DB.Order("timestamp").Limit(1).Find(&res).Error
+		if err != nil {
+			return time.Time{}, err
+		}
+		if !res.Timestamp.IsZero() {
+			return res.Timestamp, err
+		}
+	}
+
+	// If we never jumped nor have coin_price (maybe it is the first launch ?) we'll use Now()
+	return time.Now(), nil
+}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -44,3 +44,9 @@ func OrderBy(columns ...string) QueryFilter {
 		return q.Order(strings.Join(columns, ", "))
 	}
 }
+
+func Limit(limit int) QueryFilter {
+	return func(q *gorm.DB) *gorm.DB {
+		return q.Limit(limit)
+	}
+}

--- a/pkg/service/pair.go
+++ b/pkg/service/pair.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"gorm.io/gorm"
-
 	"github.com/erwanlbp/trading-bot/pkg/model"
 	"github.com/erwanlbp/trading-bot/pkg/repository"
 	"github.com/erwanlbp/trading-bot/pkg/util"
@@ -26,14 +24,32 @@ func (s *Service) InitializePairs(ctx context.Context) error {
 		return fmt.Errorf("failed getting existing pairs: %w", err)
 	}
 
-	var pairsToSave []model.Pair
-	var coinsNeedingPrice []string
+	jumps, err := s.Repository.GetJumps()
+	if err != nil {
+		return fmt.Errorf("failed to get jumps: %w", err)
+	}
+
+	lastJumpToCoin := make(map[string]model.Jump)
+	for _, jump := range jumps {
+		// Safety check
+		if jump.Timestamp.IsZero() {
+			continue
+		}
+		if lastJump := lastJumpToCoin[jump.ToCoin]; lastJump.Timestamp.IsZero() || jump.Timestamp.After(lastJump.Timestamp) {
+			lastJumpToCoin[jump.ToCoin] = jump
+		}
+	}
+
+	var pairsNeedingBotStartPriceToSave, pairsNeedingLastJumpPriceToSave []model.Pair
+	var coinsNeedingBotStartPrice []string
 	for _, coinFrom := range coins {
 		for _, coinTo := range coins {
 			if coinFrom == coinTo {
 				continue
 			}
 			pair, ok := allPairs[util.Symbol(coinFrom, coinTo)]
+
+			// If pair is in DB and have a ratio, nothing to do
 			if ok && !pair.LastJumpRatio.IsZero() {
 				continue
 			}
@@ -43,37 +59,62 @@ func (s *Service) InitializePairs(ctx context.Context) error {
 				continue
 			}
 
+			// If pair is not in DB, we'll create it in DB, and fetch the pair prices to initiate last_jump_ratio
 			if !ok {
 				pair = model.Pair{FromCoin: coinFrom, ToCoin: coinTo, Exists: true}
 			}
 
-			coinsNeedingPrice = append(coinsNeedingPrice, pair.FromCoin, pair.ToCoin)
+			if lastJump, ok := lastJumpToCoin[pair.ToCoin]; ok {
+				// If we did already jump to this coin, we initialize the ratio at the last jump timestamp
+				// As jumps have different timestamps we have to fetch the prices coin per coin
+				fromPrice, err := s.Binance.GetSymbolPriceAtTime(ctx, pair.FromCoin, s.ConfigFile.Bridge, lastJump.Timestamp)
+				if err != nil {
+					return fmt.Errorf("failed getting from_coin(%s) price at time(%s): %w", pair.FromCoin, lastJump.Timestamp, err)
+				}
+				toPrice, err := s.Binance.GetSymbolPriceAtTime(ctx, pair.ToCoin, s.ConfigFile.Bridge, lastJump.Timestamp)
+				if err != nil {
+					return fmt.Errorf("failed getting to_coin(%s) price at time(%s): %w", pair.ToCoin, lastJump.Timestamp, err)
+				}
 
-			pairsToSave = append(pairsToSave, pair)
+				if !toPrice.Price.Equal(decimal.Zero) {
+					pair.LastJumpRatio = fromPrice.Price.Div(toPrice.Price)
+					pair.LastJumpRatioBasedOn = lastJump.Timestamp
+					pairsNeedingLastJumpPriceToSave = append(pairsNeedingLastJumpPriceToSave, pair)
+				}
+			} else {
+				// If we never jump to this coin, we initialize the ratio at the bot start date
+				coinsNeedingBotStartPrice = append(coinsNeedingBotStartPrice, pair.FromCoin, pair.ToCoin)
+				pairsNeedingBotStartPriceToSave = append(pairsNeedingBotStartPriceToSave, pair)
+			}
 		}
 	}
 
-	prices, err := s.Binance.GetCoinsPrice(ctx, coinsNeedingPrice, []string{s.ConfigFile.Bridge})
-	if err != nil {
-		return fmt.Errorf("failed getting coins prices: %w", err)
-	}
-
-	for i, pair := range pairsToSave {
-		fromPrice := prices[util.Symbol(pair.FromCoin, s.ConfigFile.Bridge)].Price
-		toPrice := prices[util.Symbol(pair.ToCoin, s.ConfigFile.Bridge)].Price
-		if !toPrice.Equal(decimal.Zero) {
-			pair.LastJumpRatio = fromPrice.Div(toPrice)
-			pairsToSave[i] = pair
+	if len(coinsNeedingBotStartPrice) > 0 {
+		// Group the price getting for pairs that need "bot start" price
+		botStartTime, err := s.Repository.GetBotFirstLaunch()
+		if err != nil {
+			return fmt.Errorf("failed to get bot first launch datetime: %w", err)
+		}
+		prices, err := s.Binance.GetCoinsPrice(ctx, coinsNeedingBotStartPrice, []string{s.ConfigFile.Bridge})
+		if err != nil {
+			return fmt.Errorf("failed getting coins prices: %w", err)
+		}
+		for i, pair := range pairsNeedingBotStartPriceToSave {
+			fromPrice := prices[util.Symbol(pair.FromCoin, s.ConfigFile.Bridge)].Price
+			toPrice := prices[util.Symbol(pair.ToCoin, s.ConfigFile.Bridge)].Price
+			if !toPrice.Equal(decimal.Zero) {
+				pair.LastJumpRatio = fromPrice.Div(toPrice)
+				pair.LastJumpRatioBasedOn = botStartTime
+				pairsNeedingBotStartPriceToSave[i] = pair
+			}
 		}
 	}
 
-	if err := s.Repository.DB.Transaction(func(tx *gorm.DB) error {
-		return repository.SimpleUpsert(tx, pairsToSave...)
-	}); err != nil {
+	if err := repository.SimpleUpsert(s.Repository.DB.DB, append(pairsNeedingBotStartPriceToSave, pairsNeedingLastJumpPriceToSave...)...); err != nil {
 		return fmt.Errorf("failed saving: %w", err)
 	}
 
-	s.Logger.Info(fmt.Sprintf("Initialized %d pairs", len(pairsToSave)))
+	s.Logger.Info(fmt.Sprintf("Initialized %d pairs at 'bot start' ratio, and %d pairs at 'last jump to' ratio", len(pairsNeedingBotStartPriceToSave), len(pairsNeedingLastJumpPriceToSave)))
 
 	return nil
 }

--- a/pkg/telegram/handlers/configuration.go
+++ b/pkg/telegram/handlers/configuration.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
 	"gopkg.in/telebot.v3"
 
 	"github.com/erwanlbp/trading-bot/pkg/config/configfile"
@@ -58,6 +59,7 @@ func (p *Handlers) ShowLiveConfig(c telebot.Context) error {
 
 func (p *Handlers) ReloadConfigFile(c telebot.Context) error {
 	if err := p.GlobalConf.ReloadConfigFile(context.Background()); err != nil {
+		p.Logger.Error("Failed to reload config file", zap.Error(err))
 		return c.Send(fmt.Sprintf("Failed to reload config file: %s", err.Error()))
 	}
 
@@ -117,7 +119,7 @@ func (p *Handlers) ValidateCoinEdit(c telebot.Context) error {
 	}
 
 	newConf := util.Copy(*p.Conf)
-	newConf.Coins = util.Distinct(coins)
+	newConf.Coins = util.Distinct(util.FilterSlice(coins, func(coin string) bool { return strings.TrimSpace(coin) != "" }))
 	sort.Strings(newConf.Coins)
 
 	if err := newConf.SaveToFile(); err != nil {

--- a/pkg/telegram/handlers/last_ten_jumps.go
+++ b/pkg/telegram/handlers/last_ten_jumps.go
@@ -5,12 +5,14 @@ import (
 	"time"
 
 	"gopkg.in/telebot.v3"
+
+	"github.com/erwanlbp/trading-bot/pkg/repository"
 )
 
 func (p *Handlers) LastTenJumps(ctx context.Context) {
 	p.TelegramClient.CreateHandler(&btnLast10Jumps, func(c telebot.Context) error {
 
-		jump, err := p.Repository.GetJumps(10)
+		jump, err := p.Repository.GetJumps(repository.OrderBy("timestamp desc"), repository.Limit(10))
 		if err != nil {
 			return c.Send("Error while getting last ten jump, please retry")
 		}

--- a/pkg/util/debug.go
+++ b/pkg/util/debug.go
@@ -7,9 +7,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func DebugPrintJson(x interface{}) {
-	b, _ := json.Marshal(x)
-	fmt.Println(string(b))
+func DebugPrintJson(x ...interface{}) {
+	for _, e := range x {
+		b, _ := json.Marshal(e)
+		fmt.Println(string(b))
+	}
 }
 
 func DebugPrintYaml(x interface{}) {


### PR DESCRIPTION
- Quand on demande d'initialiser les paires (startup du bot ou reload de la conf)
  - Si on trouve pas de `last_jump` vers le `to_coin`
    - On initialise avec le prix à la date du "bot start" (trouvé avec le `min(timestamp) from jumps`)
  - Si on trouve un `last_jump` vers le `to_coin`
    - On fetch le prix de binance pour les 2 coins de la paire à la date du jump
      - On query `1` bougie de `1min`, à la date `lastJump.timestamp` => binance nous donne la dernière bougie à la date
      - On fait la moyenne entre le prix d'ouverture de la bougie et le prix de fermeture


TODO (j'ai créé une issue)
- [ ] Au moment d'init les paires, si un des coin a pas de prix pour la date du last_jump, ca retourne une erreur
  - Ca empeche le bot de démarrer si c'est au startup 😬 
  - Ca va cancel le reload de la conf si c'est live 😬 
  - C'est à gérer assez rapidement, mais j'ai pas encore décidé quel prix prendre dans ce cas là ... 
  - (si c'est un nouveau coin par exemple (le prix du STRK au lancement c'était une dinguerie) j'ai peur que ca fausse un peu les ratios ...)